### PR TITLE
Add GitHub action to push to S3

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,33 @@
+name: Deploy to master
+on:
+  push:
+    branches:    
+      - master
+
+jobs:
+  build:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - run: /bin/bash -c "npm run build"
+      - name: AWS Deploy
+        uses: docker://gcr.io/cdssnc/aws:latest
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:
+          entrypoint: sh
+          args: -l -c "aws s3 sync /github/workspace/build/. s3://${{ secrets.AWS_BUCKET }} --delete --exclude='.git'"
+      - name: AWS Invalidate
+        uses: docker://gcr.io/cdssnc/aws:latest
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:
+          entrypoint: sh
+          args: -l -c "aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_ID }} --paths \"/*\""


### PR DESCRIPTION
## Context:

This PR will alter the github actions step to build and push the website to AWS, where it will be hosted via Cloudfront & S3.

This matches how we host both digital.canada.ca and alpha.canada.ca and is our recommendation currently. Github currently missed a check on the https-everywhere.canada.ca project (HSTS or a cipher mismatch, i forget which), that reduces compliance.